### PR TITLE
Upadate fapolicyd-selinux

### DIFF
--- a/fapolicyd.fc
+++ b/fapolicyd.fc
@@ -1,3 +1,7 @@
+/etc/fapolicyd(/.*)?			 gen_context(system_u:object_r:fapolicyd_config_t,s0)
+
+/usr/lib/systemd/system/fapolicyd.*   --	gen_context(system_u:object_r:fapolicyd_unit_file_t,s0)
+
 /usr/sbin/fapolicyd		--	 gen_context(system_u:object_r:fapolicyd_exec_t,s0)
 
 /var/lib/fapolicyd(/.*)?		 gen_context(system_u:object_r:fapolicyd_var_lib_t,s0)

--- a/fapolicyd.te
+++ b/fapolicyd.te
@@ -9,11 +9,18 @@ type fapolicyd_t;
 type fapolicyd_exec_t; 
 init_daemon_domain(fapolicyd_t, fapolicyd_exec_t)
 
+type fapolicyd_config_t;
+files_type(fapolicyd_config_t)
+files_ro_base_file(fapolicyd_config_t)
+
 type fapolicyd_var_lib_t;
 files_type(fapolicyd_var_lib_t)
 
 type fapolicyd_log_t;
 logging_log_file(fapolicyd_log_t)
+
+type fapolicyd_unit_file_t;
+systemd_unit_file(fapolicyd_unit_file_t)
 
 type fapolicyd_var_run_t;
 files_pid_file(fapolicyd_var_run_t)
@@ -46,6 +53,8 @@ files_pid_filetrans(fapolicyd_t, fapolicyd_var_run_t, { dir file lnk_file })
 kernel_dgram_send(fapolicyd_t)
 
 auth_read_passwd(fapolicyd_t)
+
+corecmd_exec_bin(fapolicyd_t)
 
 domain_read_all_domains_state(fapolicyd_t)
 


### PR DESCRIPTION
Added fapolicyd_config_t label for /etc/fapolicyd.
Make fapolicyd a base read only file-readable for all domains.
Allow fapolicyd to execute generic programs in system bin directories (/bin, /sbin, /usr/bin, /usr/sbin) a without domain transition.

After start fapolicy service with fapolicy selinux module, this AVC was created:

type=AVC msg=audit(10/07/2019 09:13:27.464:304) : avc:  denied  { map } for  pid=2737 comm=fapolicyd path=/etc/fapolicyd/fapolicyd.conf dev="vda1" ino=262179 scontext=system_u:system_r:fapolicyd_t:s0 tcontext=system_u:object_r:etc_t:s0 tclass=file permissive=0


$ rpm -q selinux-policy
selinux-policy-3.14.5-8.fc32.noarch

$ ls -Z /etc/fapolicyd/
system_u:object_r:etc_t:s0 fapolicyd.conf  
system_u:object_r:etc_t:s0 fapolicyd.rules

$ ls -Z /usr/lib/systemd/system/fapolicyd*
system_u:object_r:systemd_unit_file_t:s0 /usr/lib/systemd/system/fapolicyd.service

$ sesearch -A -s fapolicyd_t -t fapolicyd_config_t -p map -c file

Scratch build installed:

$ rpm -q selinux-policy
selinux-policy-3.14.5-3.fc32.21.noarch

$ ls -Z /etc/fapolicyd/
system_u:object_r:fapolicyd_config_t:s0 fapolicyd.conf  
system_u:object_r:fapolicyd_config_t:s0 fapolicyd.rules

$ ls -Z /usr/lib/systemd/system/fapolicyd*
system_u:object_r:fapolicyd_unit_file_t:s0 /usr/lib/systemd/system/fapolicyd.service

$ sesearch -A -s fapolicyd_t -t fapolicyd_config_t -p map -c file
allow fapolicyd_t base_ro_file_type:file { execute execute_no_trans getattr ioctl lock map open read };