### PR TITLE
Allow fapolicyd create fifo files with own label

### DIFF
--- a/fapolicyd.te
+++ b/fapolicyd.te
@@ -48,7 +48,7 @@ manage_dirs_pattern(fapolicyd_t, fapolicyd_var_run_t, fapolicyd_var_run_t)
 manage_files_pattern(fapolicyd_t, fapolicyd_var_run_t, fapolicyd_var_run_t)
 manage_fifo_files_pattern(fapolicyd_t, fapolicyd_var_run_t,fapolicyd_var_run_t)
 manage_lnk_files_pattern(fapolicyd_t, fapolicyd_var_run_t, fapolicyd_var_run_t)
-files_pid_filetrans(fapolicyd_t, fapolicyd_var_run_t, { dir file lnk_file })
+files_pid_filetrans(fapolicyd_t, fapolicyd_var_run_t, { dir file fifo_file lnk_file })
 
 kernel_dgram_send(fapolicyd_t)
 


### PR DESCRIPTION
- Label all fifo_file as fapolicyd_var_run_t in /var/run.
- Allow fapolicyd_t domain to create fifo files labeled as
  fapolicyd_var_run_t