### PR TITLE
Allow fapolicyd fs_watch_with_perm and fs_watch_mount tmpfs dirs

### DIFF
--- a/fapolicyd.te
+++ b/fapolicyd.te
@@ -61,10 +61,20 @@ domain_read_all_domains_state(fapolicyd_t)
 
 files_mmap_usr_files(fapolicyd_t)
 files_read_all_files(fapolicyd_t)
+files_watch_mount_generic_tmp_dirs(fapolicyd_t)
+files_watch_with_perm_generic_tmp_dirs(fapolicyd_t)
+files_watch_mount_root_dirs(fapolicyd_t)
+files_watch_with_perm_root_dirs(fapolicyd_t)
+
 fs_getattr_xattr_fs(fapolicyd_t)
+fs_watch_mount_tmpfs_dirs(fapolicyd_t)
+fs_watch_with_perm_tmpfs_dirs(fapolicyd_t)
 
 logging_send_syslog_msg(fapolicyd_t)
 dbus_system_bus_client(fapolicyd_t)
+
+userdom_watch_mount_tmp_dirs(fapolicyd_t)
+userdom_watch_with_perm_tmp_dirs(fapolicyd_t)
 
 optional_policy(`
         rpm_read_db(fapolicyd_t)


### PR DESCRIPTION
New watch permissions have been introduced info selinux-policy.
The fapolicyd daemon needs watch permissions for inotify calls
on tmpfs directories.