### PR TITLE
add fapolicyd-hardening module preventing usage of sigstop, sigkill and ptrace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ man: install-policy
 
 install-policy: all
 	semodule -i ${TARGETS}.pp.bz2
+	semodule -i fapolicyd-hardening.cil
 
 install: man
 	install -D -m 644 ${TARGETS}.pp.bz2 ${DESTDIR}${SHAREDIR}/selinux/packages/${TARGETS}.pp.bz2

--- a/fapolicyd-hardening.cil
+++ b/fapolicyd-hardening.cil
@@ -1,0 +1,1 @@
+(deny domain fapolicyd_t ( process ( ptrace sigkill sigstop ) ) )

--- a/fapolicyd-hardening.cil
+++ b/fapolicyd-hardening.cil
@@ -1,1 +1,4 @@
-(deny domain fapolicyd_t ( process ( ptrace sigkill sigstop ) ) )
+(optional fapolicyd_hardening_optional
+    (typeattributeset cil_gen_require fapolicyd_t)
+    (deny domain fapolicyd_t ( process ( ptrace sigkill sigstop ) ) )
+)


### PR DESCRIPTION
Receiving any of these signals or starting to ptrace the process leads to a system hang.
This hardening module prevents such thing to happen.

- Without the module (example for ptrace):

  ~~~
  # sesearch -A -t fapolicyd_t -c process -p ptrace
  allow abrt_dump_oops_t domain:process ptrace; [ deny_ptrace ]:False
  allow sysadm_t domain:process ptrace; [ deny_ptrace ]:False
  allow unconfined_domain_type domain:process ptrace; [ deny_ptrace ]:False
  ~~~

- With the module:

  ~~~
  # sesearch -A -t fapolicyd_t -c process -p ptrace
  --> no rule
  
  # strace -fttTvyy -p $(pgrep fapolicyd)
  strace: attach: ptrace(PTRACE_SEIZE, 3930): Permission denied ~~~
  ~~~

Note: requires policycoreutils >= -3.6-0.rc2.1 ("deny" functionality)