### PR TITLE
Allow fapolicyd to connect to Winbind for user/group resolution

### DIFF
--- a/fapolicyd.te
+++ b/fapolicyd.te
@@ -75,6 +75,7 @@ kernel_read_all_sysctls(fapolicyd_t)
 kernel_read_all_proc(fapolicyd_t)
 
 auth_read_passwd(fapolicyd_t)
+samba_stream_connect_winbind(fapolicyd_t)
 
 corecmd_exec_bin(fapolicyd_t)
 


### PR DESCRIPTION
This is required when rules based on user or group name are created and user or group name is only present in winbind backend.

Note that there is already such rule for sssd backend, inferred by `auth_read_passwd()` usage.