### PR TITLE
Rename all /var/run file context entries to /run

### DIFF
--- a/fapolicyd.fc
+++ b/fapolicyd.fc
@@ -8,6 +8,6 @@
 
 /var/log/fapolicyd-access.log    --      gen_context(system_u:object_r:fapolicyd_log_t,s0)
 
-/var/run/fapolicyd(/.*)?		 gen_context(system_u:object_r:fapolicyd_var_run_t,s0)
+/run/fapolicyd(/.*)?		 gen_context(system_u:object_r:fapolicyd_var_run_t,s0)
 
-/var/run/fapolicyd\.pid	--	 gen_context(system_u:object_r:fapolicyd_var_run_t,s0)
+/run/fapolicyd\.pid	--	 gen_context(system_u:object_r:fapolicyd_var_run_t,s0)


### PR DESCRIPTION
With the 1f76e522a ("Rename all /var/run file context entries to /run") selinux-policy commit, all /var/run file context entries moved to /run and the equivalency was inverted. Subsequently, changes in fapolicyd.fc need to be done, too, in a similar manner.