### PR TITLE
Allow fapolicyd connect to systemd-userdbd over a unix socket

### DIFF
--- a/fapolicyd.te
+++ b/fapolicyd.te
@@ -93,3 +93,7 @@ optional_policy(`
         rpm_read_db(fapolicyd_t)
         rpm_manage_db(fapolicyd_t)
 ')
+
+optional_policy(`
+	systemd_userdbd_stream_connect(fapolicyd_t)
+')


### PR DESCRIPTION
The commit addresses the following AVC denial and 2 related ones:
type=PROCTITLE msg=audit(03/13/2024 05:37:15.796:150) : proctitle=/usr/sbin/fapolicyd type=PATH msg=audit(03/13/2024 05:37:15.796:150) : item=0 name=/run/systemd/userdb/io.systemd.DropIn inode=479 dev=00:19 mode=socket,666 ouid=root ogid=root rdev=00:00 obj=system_u:object_r:systemd_userdbd_runtime_t:s0 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 type=SOCKADDR msg=audit(03/13/2024 05:37:15.796:150) : saddr={ saddr_fam=local path=/run/systemd/userdb/io.systemd.DropIn } type=SYSCALL msg=audit(03/13/2024 05:37:15.796:150) : arch=x86_64 syscall=connect success=no exit=EACCES(Permission denied) a0=0x8 a1=0x7ffc6c364060 a2=0x28 a3=0x4 items=1 ppid=1 pid=898 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=fapolicyd exe=/usr/sbin/fapolicyd subj=system_u:system_r:fapolicyd_t:s0 key=(null) type=AVC msg=audit(03/13/2024 05:37:15.796:150) : avc:  denied  { connectto } for  pid=898 comm=fapolicyd path=/run/systemd/userdb/io.systemd.Multiplexer scontext=system_u:system_r:fapolicyd_t:s0 tcontext=system_u:system_r:systemd_userdbd_t:s0 tclass=unix_stream_socket permissive=0