### PR TITLE
Make systemd_userdbd_stream_connect() interface call conditional

### DIFF
--- a/fapolicyd.te
+++ b/fapolicyd.te
@@ -94,6 +94,8 @@ optional_policy(`
         rpm_manage_db(fapolicyd_t)
 ')
 
-optional_policy(`
-	systemd_userdbd_stream_connect(fapolicyd_t)
+ifdef(`systemd_userdbd_stream_connect',`
+	optional_policy(`
+		systemd_userdbd_stream_connect(fapolicyd_t)
+	')
 ')


### PR DESCRIPTION
The systemd_userdbd_stream_connect() interface may not be defined in older releases, so a check if the interface exists was added.