### PR TITLE
Add file context entry for /usr/bin/fapolicyd

### DIFF
--- a/fapolicyd.fc
+++ b/fapolicyd.fc
@@ -2,6 +2,7 @@
 
 /usr/lib/systemd/system/fapolicyd.*   --	gen_context(system_u:object_r:fapolicyd_unit_file_t,s0)
 
+/usr/bin/fapolicyd		--	 gen_context(system_u:object_r:fapolicyd_exec_t,s0)
 /usr/sbin/fapolicyd		--	 gen_context(system_u:object_r:fapolicyd_exec_t,s0)
 
 /var/lib/fapolicyd(/.*)?		 gen_context(system_u:object_r:fapolicyd_var_lib_t,s0)


### PR DESCRIPTION
To comply with the "Unify bin and sbin" Fedora Change [1], file equivalency for the /bin, /sbin, and /usr/bin paths are now set in selinux-policy. This requires follow-up changes in DSP modules, too.

[1] https://fedoraproject.org/wiki/Changes/Unify_bin_and_sbin