### PR TITLE
Allow fapolicy to write to tmpfs

### DIFF
--- a/fapolicyd.te
+++ b/fapolicyd.te
@@ -55,6 +55,7 @@ ifdef(`fs_watch_all_fs',`
 
 allow fapolicyd_t file_type : lnk_file { getattr read };
 allow fapolicyd_t var_run_t:dir setattr;
+allow fapolicyd_t tmpfs_t:file write;
 
 manage_files_pattern(fapolicyd_t, fapolicyd_log_t, fapolicyd_log_t)
 logging_log_filetrans(fapolicyd_t, fapolicyd_log_t, file)


### PR DESCRIPTION
- fapolicyd-rpm-loader writes data to memfd now https://github.com/linux-application-whitelisting/fapolicyd/pull/346