### PR TITLE
Bring back /var/run/ contexts

### DIFF
--- a/fapolicyd.fc
+++ b/fapolicyd.fc
@@ -10,5 +10,7 @@
 /var/log/fapolicyd-access.log    --      gen_context(system_u:object_r:fapolicyd_log_t,s0)
 
 /run/fapolicyd(/.*)?		 gen_context(system_u:object_r:fapolicyd_var_run_t,s0)
+/var/run/fapolicyd(/.*)?		 gen_context(system_u:object_r:fapolicyd_var_run_t,s0)
 
 /run/fapolicyd\.pid	--	 gen_context(system_u:object_r:fapolicyd_var_run_t,s0)
+/var/run/fapolicyd\.pid	--	 gen_context(system_u:object_r:fapolicyd_var_run_t,s0)


### PR DESCRIPTION
Commit 750c5e288f82 ("Rename all /var/run file context entries to /run") removed all /var/run entries to follow /var/run -> /run change in selinux-policy. This change has not been applied in c9s and so it's necessary to provide also the original context mappings.